### PR TITLE
Apt patch

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,8 +25,8 @@ class r1soft {
           src => false,
         },
         key      => {
-          id      => '66BD1D82',
-          source  => 'http://repo.r1soft.com/r1soft.asc',
+          id     => '66BD1D82',
+          source => 'http://repo.r1soft.com/r1soft.asc',
         },
       }
       # Set the right java package, this can be used later on with java_ks

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,15 +17,18 @@ class r1soft {
     }
     'debian', 'ubuntu': {
       apt::source { 'r1soft':
-        comment     => 'R1Soft Server Backup Manager Repository',
-        location    => 'http://repo.r1soft.com/apt',
-        release     => 'stable',
-        repos       => 'main',
-        include_src => false,
-        key         => '66BD1D82',
-        key_source  => 'http://repo.r1soft.com/r1soft.asc',
+        comment  => 'R1Soft Server Backup Manager Repository',
+        location => 'http://repo.r1soft.com/apt',
+        release  => 'stable',
+        repos    => 'main',
+        include  => {
+          src => false,
+        },
+        key      => {
+          id      => '66BD1D82',
+          source  => 'http://repo.r1soft.com/r1soft.asc',
+        },
       }
-
       # Set the right java package, this can be used later on with java_ks
       $java_package = 'openjdk-7-jre-headless'
     }

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.3.2 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">=1.7.0 < 5.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 5.0.0" },
     { "name": "puppetlabs/java_ks", "version_requirement": ">=1.2.6 < 2.0.0" }
   ]
 }


### PR DESCRIPTION
Patch to use the new apt configuration for keys introduced in puppetlabs-apt 2.0.0 as the old variables have since been removed.